### PR TITLE
Add conjunctival ROI segmentation and bbox extraction pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,80 @@
-"# week3_box" 
+# Conjunctival ROI Pipeline
+
+This repository provides a minimal pipeline to train a U-Net on conjunctival ROI masks and
+apply the trained model to generate bounding boxes for new eye images. Three datasets are
+assumed:
+
+1. **Conjunctival Images for Anemia Detection** – contains paired eye images and palpebral masks.
+2. **Eye Conjunctiva Segmentation Dataset** – images and masks are stored in separate folders.
+3. **Palpebral Conjunctiva Dataset** – only eye images, used for inference.
+
+## Dataset layouts
+
+```
+Conjunctival Images for Anemia Detection/
+├── India/1/20200124_155418.jpg
+├── India/1/20200124_155418_palpebral.png
+└── ...
+
+Eye Conjunctiva Segmentation Dataset/
+├── images/img_001.jpg
+└── masks/img_001.png
+
+Palpebral Conjunctiva Dataset/
+├── img_1_001.jpg
+└── ...
+```
+
+## Training
+
+`train.py` accepts multiple datasets at once. For each dataset specify the image root,
+mask root and mask suffix. Aspect ratio is preserved with padding during resizing.
+
+Example (using the first dataset only):
+
+```
+python train.py --img-root "Conjunctival Images for Anemia Detection" \
+                --mask-root "Conjunctival Images for Anemia Detection" \
+                --mask-suffix "_palpebral.png" \
+                --epochs 50 --out stage1.pt
+```
+
+Training with both mask datasets:
+
+```
+python train.py --img-root "Conjunctival Images for Anemia Detection" \
+                             "Eye Conjunctiva Segmentation Dataset/images" \
+                --mask-root "Conjunctival Images for Anemia Detection" \
+                             "Eye Conjunctiva Segmentation Dataset/masks" \
+                --mask-suffix "_palpebral.png" ".png" \
+                --epochs 50 --out stage1.pt
+```
+
+## Inference & Bounding boxes
+
+Apply a trained checkpoint to images that have no mask to obtain bounding boxes.
+The bounding boxes are saved as `*_bbox.json` suitable as prompts for SlimSAM.
+
+```
+python inference_bbox.py --img-root "Palpebral Conjunctiva Dataset" \
+                         --ckpt stage1.pt \
+                         --out-dir preds_bbox \
+                         --img-size 256
+```
+
+Each JSON file contains
+
+```json
+{"bbox": [x1, y1, x2, y2]}
+```
+
+where coordinates are in the original image size.
+
+## Modules
+- `datasets.py` – dataset loader with optional masks and aspect ratio preserving resize.
+- `unet.py` – U-Net architecture (in_channels=3, out_channels=1).
+- `train.py` – training script saving a `.pt` checkpoint.
+- `inference_bbox.py` – generate bounding boxes from predicted masks.
+
+## License
+MIT

--- a/datasets.py
+++ b/datasets.py
@@ -1,0 +1,75 @@
+import os
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import numpy as np
+from PIL import Image
+import torch
+from torch.utils.data import Dataset
+import torchvision.transforms.functional as TF
+
+
+def resize_with_padding(img: Image.Image, size: int, interpolation=Image.BILINEAR):
+    """Resize image keeping aspect ratio and pad to square."""
+    w, h = img.size
+    scale = size / max(w, h)
+    new_w, new_h = int(round(w * scale)), int(round(h * scale))
+    img = img.resize((new_w, new_h), interpolation)
+    new_img = Image.new(img.mode, (size, size))
+    pad_left = (size - new_w) // 2
+    pad_top = (size - new_h) // 2
+    new_img.paste(img, (pad_left, pad_top))
+    return new_img, scale, (pad_left, pad_top)
+
+
+class ConjunctivaDataset(Dataset):
+    """Dataset for conjunctival ROI segmentation or inference."""
+
+    def __init__(
+        self,
+        img_root: str,
+        mask_root: Optional[str] = None,
+        mask_suffix: Optional[str] = None,
+        img_size: int = 256,
+    ) -> None:
+        self.img_root = Path(img_root)
+        self.mask_root = Path(mask_root) if mask_root is not None else None
+        self.mask_suffix = mask_suffix
+        self.img_size = img_size
+        self.has_mask = self.mask_root is not None and self.mask_suffix is not None
+
+        self.samples: List[Tuple[Path, Optional[Path]]] = []
+        for img_path in sorted(self.img_root.rglob("*.jpg")):
+            if self.has_mask:
+                if self.mask_root == self.img_root:
+                    mask_path = img_path.with_name(img_path.stem + self.mask_suffix)
+                else:
+                    mask_path = self.mask_root / (img_path.stem + self.mask_suffix)
+                if mask_path.exists():
+                    self.samples.append((img_path, mask_path))
+            else:
+                self.samples.append((img_path, None))
+
+    def __len__(self) -> int:
+        return len(self.samples)
+
+    def __getitem__(self, idx: int):
+        img_path, mask_path = self.samples[idx]
+        img = Image.open(img_path).convert("RGB")
+        orig_size = img.size
+        img_resized, scale, pad = resize_with_padding(img, self.img_size)
+        img_tensor = TF.to_tensor(img_resized)
+
+        if mask_path is not None:
+            mask = Image.open(mask_path).convert("L")
+            mask_resized, _, _ = resize_with_padding(mask, self.img_size, Image.NEAREST)
+            mask_tensor = torch.from_numpy(np.array(mask_resized) / 255.0).unsqueeze(0).float()
+            return img_tensor, mask_tensor
+        else:
+            meta = {
+                "orig_size": orig_size,
+                "scale": scale,
+                "pad": pad,
+                "path": img_path,
+            }
+            return img_tensor, meta

--- a/inference_bbox.py
+++ b/inference_bbox.py
@@ -1,0 +1,72 @@
+import argparse
+import json
+from pathlib import Path
+
+import torch
+from torch.utils.data import DataLoader
+import numpy as np
+
+from datasets import ConjunctivaDataset
+from unet import UNet
+
+
+def map_bbox_to_original(bbox, meta):
+    (w, h) = meta["orig_size"]
+    scale = meta["scale"]
+    pad_left, pad_top = meta["pad"]
+    x1, y1, x2, y2 = bbox
+    x1 = (x1 - pad_left) / scale
+    x2 = (x2 - pad_left) / scale
+    y1 = (y1 - pad_top) / scale
+    y2 = (y2 - pad_top) / scale
+    x1 = max(0, min(w - 1, x1))
+    x2 = max(0, min(w - 1, x2))
+    y1 = max(0, min(h - 1, y1))
+    y2 = max(0, min(h - 1, y2))
+    return [int(x1), int(y1), int(x2), int(y2)]
+
+
+def inference(img_root: str, ckpt: str, out_dir: str, img_size: int):
+    dataset = ConjunctivaDataset(img_root, mask_root=None, mask_suffix=None, img_size=img_size)
+    loader = DataLoader(dataset, batch_size=1, shuffle=False)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = UNet(in_c=3, out_c=1).to(device)
+    state = torch.load(ckpt, map_location=device)
+    model.load_state_dict(state)
+    model.eval()
+
+    out_path = Path(out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    for imgs, meta in loader:
+        imgs = imgs.to(device)
+        meta = {k: v[0] for k, v in meta.items()}
+        with torch.no_grad():
+            preds = model(imgs).sigmoid()[0, 0]
+        mask = (preds > 0.5).cpu().numpy().astype(np.uint8)
+        ys, xs = np.where(mask > 0)
+        if len(xs) == 0 or len(ys) == 0:
+            bbox_model = [0, 0, 0, 0]
+        else:
+            x1, x2 = xs.min(), xs.max()
+            y1, y2 = ys.min(), ys.max()
+            bbox_model = [x1, y1, x2, y2]
+        bbox = map_bbox_to_original(bbox_model, meta)
+        name = Path(meta["path"]).stem
+        with open(out_path / f"{name}_bbox.json", "w") as f:
+            json.dump({"bbox": bbox}, f)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Inference and save bounding boxes")
+    parser.add_argument("--img-root", required=True)
+    parser.add_argument("--ckpt", required=True)
+    parser.add_argument("--out-dir", required=True)
+    parser.add_argument("--img-size", type=int, default=256)
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    inference(args.img_root, args.ckpt, args.out_dir, args.img_size)

--- a/train.py
+++ b/train.py
@@ -1,0 +1,57 @@
+import argparse
+from pathlib import Path
+
+import torch
+from torch.utils.data import ConcatDataset, DataLoader
+
+from datasets import ConjunctivaDataset
+from unet import UNet
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Train U-Net for conjunctiva segmentation")
+    parser.add_argument("--img-root", nargs="+", required=True, help="Image root directories")
+    parser.add_argument("--mask-root", nargs="+", required=True, help="Mask root directories")
+    parser.add_argument("--mask-suffix", nargs="+", required=True, help="Mask suffix for each dataset")
+    parser.add_argument("--img-size", type=int, default=256)
+    parser.add_argument("--epochs", type=int, default=20)
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--lr", type=float, default=1e-3)
+    parser.add_argument("--out", required=True, help="Output checkpoint path")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    assert len(args.img_root) == len(args.mask_root) == len(args.mask_suffix)
+    datasets = []
+    for img_root, mask_root, mask_suffix in zip(args.img_root, args.mask_root, args.mask_suffix):
+        datasets.append(ConjunctivaDataset(img_root, mask_root, mask_suffix, args.img_size))
+    dataset = ConcatDataset(datasets)
+    loader = DataLoader(dataset, batch_size=args.batch_size, shuffle=True)
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model = UNet(in_c=3, out_c=1).to(device)
+    optimizer = torch.optim.Adam(model.parameters(), lr=args.lr)
+    criterion = torch.nn.BCEWithLogitsLoss()
+
+    for epoch in range(args.epochs):
+        model.train()
+        total_loss = 0.0
+        for imgs, masks in loader:
+            imgs = imgs.to(device)
+            masks = masks.to(device)
+            optimizer.zero_grad()
+            preds = model(imgs)
+            loss = criterion(preds, masks)
+            loss.backward()
+            optimizer.step()
+            total_loss += loss.item()
+        print(f"Epoch {epoch+1}/{args.epochs} loss {total_loss/len(loader):.4f}")
+
+    torch.save(model.state_dict(), args.out)
+    print(f"Saved checkpoint to {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/unet.py
+++ b/unet.py
@@ -1,0 +1,70 @@
+import torch
+import torch.nn as nn
+
+
+class DoubleConv(nn.Module):
+    def __init__(self, in_c, out_c):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Conv2d(in_c, out_c, 3, padding=1),
+            nn.BatchNorm2d(out_c),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(out_c, out_c, 3, padding=1),
+            nn.BatchNorm2d(out_c),
+            nn.ReLU(inplace=True),
+        )
+
+    def forward(self, x):
+        return self.net(x)
+
+
+class Down(nn.Module):
+    def __init__(self, in_c, out_c):
+        super().__init__()
+        self.net = nn.Sequential(nn.MaxPool2d(2), DoubleConv(in_c, out_c))
+
+    def forward(self, x):
+        return self.net(x)
+
+
+class Up(nn.Module):
+    def __init__(self, in_c, out_c):
+        super().__init__()
+        self.up = nn.ConvTranspose2d(in_c // 2, in_c // 2, 2, stride=2)
+        self.conv = DoubleConv(in_c, out_c)
+
+    def forward(self, x1, x2):
+        x1 = self.up(x1)
+        diffY = x2.size()[2] - x1.size()[2]
+        diffX = x2.size()[3] - x1.size()[3]
+        x1 = nn.functional.pad(x1, [diffX // 2, diffX - diffX // 2, diffY // 2, diffY - diffY // 2])
+        x = torch.cat([x2, x1], dim=1)
+        return self.conv(x)
+
+
+class UNet(nn.Module):
+    def __init__(self, in_c=3, out_c=1, base_c=64):
+        super().__init__()
+        self.inc = DoubleConv(in_c, base_c)
+        self.down1 = Down(base_c, base_c * 2)
+        self.down2 = Down(base_c * 2, base_c * 4)
+        self.down3 = Down(base_c * 4, base_c * 8)
+        self.down4 = Down(base_c * 8, base_c * 8)
+        self.up1 = Up(base_c * 16, base_c * 4)
+        self.up2 = Up(base_c * 8, base_c * 2)
+        self.up3 = Up(base_c * 4, base_c)
+        self.up4 = Up(base_c * 2, base_c)
+        self.outc = nn.Conv2d(base_c, out_c, 1)
+
+    def forward(self, x):
+        x1 = self.inc(x)
+        x2 = self.down1(x1)
+        x3 = self.down2(x2)
+        x4 = self.down3(x3)
+        x5 = self.down4(x4)
+        x = self.up1(x5, x4)
+        x = self.up2(x, x3)
+        x = self.up3(x, x2)
+        x = self.up4(x, x1)
+        logits = self.outc(x)
+        return logits


### PR DESCRIPTION
## Summary
- implement dataset loader with aspect-ratio preserving padding and optional mask handling
- add U-Net model, training script supporting multiple datasets, and inference script generating SlimSAM-style bounding boxes
- document dataset layouts and usage in README

## Testing
- `python -m py_compile datasets.py unet.py train.py inference_bbox.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c6d30e553c832bbfd181e5b931da8a